### PR TITLE
Adding name to cover page works, but not location

### DIFF
--- a/RingCentral/Definitions/MessageStoreCallerInfoRequest.cs
+++ b/RingCentral/Definitions/MessageStoreCallerInfoRequest.cs
@@ -4,5 +4,9 @@ namespace RingCentral
     {
         // Phone number in E.164 format
         public string @phoneNumber { get; set; }
+        
+        public string @name { get; set; }
+        
+        public string @location { get; set; }
     }
 }


### PR DESCRIPTION
I tried adding name field to my code and it appears on the cover page. But the location is ignored.

public class CallerInfoRequest : MessageStoreCallerInfoRequest
        {
            public string name;
            public string location;
        }